### PR TITLE
Views Initialization in FE State & Resource View in Dashboard

### DIFF
--- a/ui/app/src/elements/components/table.ts
+++ b/ui/app/src/elements/components/table.ts
@@ -1,5 +1,6 @@
 import { html, css, TemplateResult } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
+import { ref } from "lit/directives/ref.js";
 
 import {
   FieldDefinitions,
@@ -68,8 +69,8 @@ export class StatefulTable extends NHComponentShoelace {
         heading: generateHeaderHTML('Resource', resourceName),
         decorator: (resource: any) => html`<div
           style="width: 100%; display: grid;place-content: start center; height: 100%; justify-items: center;"
+          ${typeof resource.eh[1] === 'function' ? ref((e) => resource.eh[1](e as HTMLElement, resource.eh[0])) : null}
         >
-          ${typeof resource.eh[1] === 'function' ? resource.eh[1](html``, resource.eh[0]) : generateHashHTML(resource.eh[0])}
         </div>`,
       }),
       neighbour: new FieldDefinition<AssessmentTableRecord>({

--- a/ui/app/src/elements/components/table.ts
+++ b/ui/app/src/elements/components/table.ts
@@ -69,7 +69,7 @@ export class StatefulTable extends NHComponentShoelace {
         decorator: (resource: any) => html`<div
           style="width: 100%; display: grid;place-content: start center; height: 100%; justify-items: center;"
         >
-          ${generateHashHTML(resource.eh)}
+          ${typeof resource.eh[1] === 'function' ? resource.eh[1](html``, resource.eh[0]) : generateHashHTML(resource.eh[0])}
         </div>`,
       }),
       neighbour: new FieldDefinition<AssessmentTableRecord>({

--- a/ui/app/src/elements/dashboard/nh-sensemaker-settings.ts
+++ b/ui/app/src/elements/dashboard/nh-sensemaker-settings.ts
@@ -33,10 +33,9 @@ export class NHSensemakerSettings extends NHComponentShoelace {
     store &&
       store.subscribe(appletConfig => {
         this.appletDetails = appletConfig;
-        if (Object.values(appletConfig.resource_defs).length <= 1)
+        if (Object.values(appletConfig.resource_defs).length < 1)
           return console.log("Didn't register the applet's resource defs yet");
         this.activeMethodsDict = Object.entries(appletConfig.resource_defs)
-          .slice(1)
           .reduce(
             // Slice to remove Generic Resource
             (dict, [_, eH]): any => {
@@ -190,7 +189,6 @@ export class NHSensemakerSettings extends NHComponentShoelace {
 
     return html`
       ${Object.entries(this.appletDetails.resource_defs)
-        .slice(1)
         .map(([key, eH]: any) => {
           const resourceDefEh = encodeHashToBase64(eH);
           const activeMethod = this.activeMethodsDict.get(resourceDefEh);

--- a/ui/app/src/main-dashboard.ts
+++ b/ui/app/src/main-dashboard.ts
@@ -216,7 +216,7 @@ export class MainDashboard extends NHComponentShoelace {
       `;
       // show all applet classes in NavigationMode.Agnostic
     } else {
-      return html` ${this.renderAppletClassListSecondary(this._allAppletClasses.value.values())} `;
+      return html``;
     }
   }
 

--- a/ui/app/src/main-dashboard.ts
+++ b/ui/app/src/main-dashboard.ts
@@ -294,7 +294,7 @@ export class MainDashboard extends NHComponentShoelace {
     }
   }
 
-  handleWeGroupIconPrimaryClick(weGroupId: DnaHash) {
+  async handleWeGroupIconPrimaryClick(weGroupId: DnaHash) {
     this._navigationMode = NavigationMode.GroupCentric;
     if (this._selectedWeGroupId !== weGroupId) {
       this._selectedAppletInstanceId = undefined;
@@ -302,6 +302,11 @@ export class MainDashboard extends NHComponentShoelace {
     }
     this._dashboardMode = DashboardMode.WeGroupHome;
     this._selectedWeGroupId = weGroupId;
+
+
+    // initialize widgets for group
+    console.log("initializing views for group")
+    await this._matrixStore.initializeViewsForGroup(weGroupId);
   }
 
   handleWeGroupIconSecondaryClick(weGroupId: DnaHash, appletId: EntryHash) {
@@ -401,8 +406,9 @@ export class MainDashboard extends NHComponentShoelace {
                       style="overflow: hidden; margin-top: 2px; margin-bottom: 2px;"
                       .logoSrc=${weGroupInfo.info.logoSrc}
                       .tooltipText=${weGroupInfo.info.name}
-                      @click=${() => {
-                        this.handleWeGroupIconPrimaryClick(weGroupInfo.dna_hash);
+                      @click=${async () => {
+                        console.log("clicked to enter group!");
+                        await this.handleWeGroupIconPrimaryClick(weGroupInfo.dna_hash);
                         this.requestUpdate();
                       }}
                       class=${classMap({

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -471,6 +471,7 @@ export class MatrixStore {
       [{ neighbourhoodInfo: this.getWeGroupInfo(weGroupId)!, appInfo }],
     );
 
+    // now that the applet instance renderers have been fetched and instantiated, add them to the AppletInstanceInfo 
     this._matrix.update((matrix) => {
       matrix.get(weGroupId)[1].find(
         (info) =>
@@ -1363,7 +1364,7 @@ export class MatrixStore {
         gui = await this.queryAppletGui(devhubHappReleaseHash);
       }
 
-      // register applet config and widgets on applet join
+      // register applet config and sensemaker dimension widgets on applet join
       console.log('register applet config and widgets', gui);
 
       const appletConfig = gui.appletConfig;

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -465,10 +465,9 @@ export class MatrixStore {
     }
 
     const renderers = await gui.appletRenderers(
+      appletAppAgentWebsocket,
       weServices,
       [{ weInfo: this.getWeGroupInfo(weGroupId)!, appInfo }],
-      this.appWebsocket,
-      appletAppAgentWebsocket,
     );
 
     return renderers;

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -52,8 +52,8 @@ import {
   AppletRenderers,
   NhLauncherApplet,
   AppletInfo,
-  WeServices,
-  WeInfo,
+  NeighbourhoodServices,
+  NeighbourhoodInfo,
 } from "@neighbourhoods/nh-launcher-applet";
 import { SensemakerStore, SensemakerService } from "@neighbourhoods/client";
 import {
@@ -92,7 +92,7 @@ export interface WeGroupData {
 
 /**Info of a group */
 export interface WeGroupInfo {
-  info: WeInfo;
+  info: NeighbourhoodInfo;
   cell_id: CellId;
   dna_hash: DnaHash;
   cloneName: string;
@@ -112,6 +112,7 @@ export interface AppletInstanceInfo {
   applet: Applet;
   federatedGroups: DnaHash[];
   appAgentWebsocket?: AppAgentClient;
+  views?: AppletRenderers;
 }
 
 export interface UninstalledAppletInstanceInfo {
@@ -277,7 +278,7 @@ export class MatrixStore {
    * @param weGroupId : DnaHash
    * @returns : WeInfo
    */
-  public getWeGroupInfo(weGroupId): WeInfo | undefined {
+  public getWeGroupInfo(weGroupId): NeighbourhoodInfo | undefined {
     if (weGroupId) {
       return get(this._matrix).get(weGroupId)
         ? get(this._matrix).get(weGroupId)[0].info.info
@@ -291,7 +292,7 @@ export class MatrixStore {
    * @param weGroupId : DnaHash
    * @returns : Promise<Readable<WeInfo>>
    */
-  public async fetchWeGroupInfo(weGroupId: DnaHash): Promise<Readable<WeInfo>> {
+  public async fetchWeGroupInfo(weGroupId: DnaHash): Promise<Readable<NeighbourhoodInfo>> {
     const appAgentWebsocket = get(this._matrix).get(weGroupId)[0].appAgentWebsocket;
     const info = await appAgentWebsocket.callZome({
       cell_id: [weGroupId, appAgentWebsocket.myPubKey],
@@ -410,7 +411,7 @@ export class MatrixStore {
    */
   async fetchAppletInstanceRenderers(
     appletInstanceId: EntryHash,
-    weServices: WeServices
+    weServices: NeighbourhoodServices
   ) {
     // // 1. check whether the renderers for this applet instance are already stored, if yes return them
     // const maybeRenderers = this._appletInstanceRenderers.get(appletInstanceId);
@@ -442,7 +443,7 @@ export class MatrixStore {
     if (!appInstanceInfo.appAgentWebsocket) {
 
       //instantiate the websocket
-      console.log('app agent websocket not instantiated yet');
+      console.log('app agent websocket being instantiated');
       const hcPort = import.meta.env.VITE_AGENT === "2" ? import.meta.env.VITE_HC_PORT_2 : import.meta.env.VITE_HC_PORT;
       appletAppAgentWebsocket = await AppAgentWebsocket.connect(`ws://localhost:${hcPort}`, appInfo.installed_app_id);
       this._matrix.update((matrix) => {
@@ -467,8 +468,17 @@ export class MatrixStore {
     const renderers = await gui.appletRenderers(
       appletAppAgentWebsocket,
       weServices,
-      [{ weInfo: this.getWeGroupInfo(weGroupId)!, appInfo }],
+      [{ neighbourhoodInfo: this.getWeGroupInfo(weGroupId)!, appInfo }],
     );
+
+    this._matrix.update((matrix) => {
+      matrix.get(weGroupId)[1].find(
+        (info) =>
+          JSON.stringify(info.appletId) === JSON.stringify(appletInstanceId)
+      )!.views = renderers;
+      return matrix;
+    })
+    
 
     return renderers;
   }
@@ -704,7 +714,9 @@ export class MatrixStore {
       UninstalledAppletInstanceInfo[]
     >();
 
+    console.log("app info from matrix", this.weParentAppInfo);
     let weParentAppInfo: AppInfo = await this.appWebsocket.appInfo({ installed_app_id: this.weParentAppInfo.installed_app_id });
+    console.log("parent app info after fetch", weParentAppInfo);
 
     // fetch all apps from the conductor
     let allApps = await this.adminWebsocket.listApps({});
@@ -1132,7 +1144,7 @@ export class MatrixStore {
       }, 1500);
     
     this._matrix.update((matrix) => {
-      const weInfo: WeInfo = {
+      const weInfo: NeighbourhoodInfo = {
         logoSrc: properties.logoSrc,
         name: properties.name,
       };
@@ -2011,7 +2023,7 @@ export class MatrixStore {
     const matrix = get(this._matrix);
     let appletInfosOfClass: AppletInfo[] = [];
     matrix.values().forEach(([weGroupData, appletInstanceInfos]) => {
-      const weInfo: WeInfo = weGroupData.info.info;
+      const weInfo: NeighbourhoodInfo = weGroupData.info.info;
       const relevantAppletInstanceInfos = appletInstanceInfos.filter(
         (info) =>
           JSON.stringify(info.applet.devhubHappReleaseHash) ===
@@ -2020,7 +2032,7 @@ export class MatrixStore {
       const relevantInstalledAppletInfos = relevantAppletInstanceInfos.map(
         (appletInstanceInfo) => {
           const installedAppletInfo: AppletInfo = {
-            weInfo,
+            neighbourhoodInfo:  weInfo,
             appInfo: appletInstanceInfo.appInfo,
           };
           return installedAppletInfo;

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -2172,4 +2172,19 @@ export class MatrixStore {
       });
     });
   }
+  getResourceView(weGroupId: DnaHash, resourceDefEh: EntryHash) {
+    const groupSenseMakerStore = get(this.sensemakerStore(weGroupId));
+    const appletConfigs = get(groupSenseMakerStore!.appletConfigs());
+    // find the applet config that contains the resource definition eh
+    const [appletName, appletConfig] = Object.entries(appletConfigs).find(([appletName, appletConfig]) => {
+      const resourceDefs = Object.values(appletConfig.resource_defs);
+      return resourceDefs.find((resourceDefEhFromConfig) => encodeHashToBase64(resourceDefEhFromConfig) === encodeHashToBase64(resourceDefEh));
+    }
+    )!;
+    // return the appplet app info for the appletName
+    const appletInstanceInfo = get(this._matrix).get(weGroupId)[1].find((appletInstanceInfo) => appletInstanceInfo.appInfo.installed_app_id === appletName);
+    // get the resource def name given the resource def eh
+    const resourceDefName = Object.entries(appletConfig.resource_defs).find(([resourceDefName, resourceDefEhFromConfig]) => encodeHashToBase64(resourceDefEhFromConfig) === encodeHashToBase64(resourceDefEh))![0];
+    return appletInstanceInfo!.views!.resourceRenderers[resourceDefName];
+  }
 }

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -1369,6 +1369,7 @@ export class MatrixStore {
       const appletConfig = gui.appletConfig;
       const widgetPairs = gui.widgetPairs;
       const sensemakerStore = get(this.sensemakerStore(weGroupId));
+      appletConfig.applet_config_input.name = installedAppId;
       await sensemakerStore?.registerApplet(appletConfig);
       widgetPairs.map((widgetPair) => {
         console.log('registering widgets to SM store')
@@ -1570,6 +1571,7 @@ export class MatrixStore {
       const appletConfig = gui.appletConfig;
       const widgetPairs = gui.widgetPairs;
       const sensemakerStore = get(this.sensemakerStore(weGroupId));
+      appletConfig.applet_config_input.name = installedAppId;
       const registeredConfig = await sensemakerStore!.registerApplet(appletConfig);
       console.log('registeredConfig', registeredConfig)
       widgetPairs.map((widgetPair) => {
@@ -2165,12 +2167,17 @@ export class MatrixStore {
 
       const appletConfig = gui.appletConfig;
       const widgetPairs = gui.widgetPairs;
-      const sensemakerStore = get(this.sensemakerStore(weGroupId));
-      const registeredConfig = await sensemakerStore!.registerApplet(appletConfig);
+      // const sensemakerStore = get(this.sensemakerStore(weGroupId));
+      appletConfig.applet_config_input.name = appletInstanceInfo.appInfo.installed_app_id;
+      const registeredConfig = await weGroupData.sensemakerStore.registerApplet(appletConfig);
       console.log('registeredConfig', registeredConfig)
       widgetPairs.map((widgetPair) => {
         console.log('registering widgets to SM store')
         get(this.sensemakerStore(weGroupId))!.registerWidget(
+          // [
+          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["importance"]),
+          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["total_importance"]),
+          // ],
           widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(registeredConfig.dimensions[dimensionName])),
           widgetPair.display,
           widgetPair.assess,

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -1374,10 +1374,6 @@ export class MatrixStore {
       widgetPairs.map((widgetPair) => {
         console.log('registering widgets to SM store')
         sensemakerStore!.registerWidget(
-          // [
-          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["importance"]),
-          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["total_importance"]),
-          // ],
           widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(get(sensemakerStore!.appletConfigs())[installedAppId].dimensions[dimensionName])),
           widgetPair.display,
           widgetPair.assess,
@@ -1577,10 +1573,6 @@ export class MatrixStore {
       widgetPairs.map((widgetPair) => {
         console.log('registering widgets to SM store')
         get(this.sensemakerStore(weGroupId))!.registerWidget(
-          // [
-          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["importance"]),
-          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["total_importance"]),
-          // ],
           widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(registeredConfig.dimensions[dimensionName])),
           widgetPair.display,
           widgetPair.assess,
@@ -2167,17 +2159,12 @@ export class MatrixStore {
 
       const appletConfig = gui.appletConfig;
       const widgetPairs = gui.widgetPairs;
-      // const sensemakerStore = get(this.sensemakerStore(weGroupId));
       appletConfig.applet_config_input.name = appletInstanceInfo.appInfo.installed_app_id;
       const registeredConfig = await weGroupData.sensemakerStore.registerApplet(appletConfig);
       console.log('registeredConfig', registeredConfig)
       widgetPairs.map((widgetPair) => {
         console.log('registering widgets to SM store')
         get(this.sensemakerStore(weGroupId))!.registerWidget(
-          // [
-          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["importance"]),
-          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["total_importance"]),
-          // ],
           widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(registeredConfig.dimensions[dimensionName])),
           widgetPair.display,
           widgetPair.assess,

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -2146,4 +2146,36 @@ export class MatrixStore {
 
     return isSame;
   }
+
+  public async initializeViewsForGroup(weGroupId: DnaHash) {
+    const [weGroupData, appletInstanceInfos] = get(this._matrix).get(weGroupId);
+    appletInstanceInfos.forEach(async (appletInstanceInfo) => {
+      await this.fetchAppletInstanceRenderers(appletInstanceInfo.appletId, {
+        profilesStore: weGroupData.profilesStore,
+        sensemakerStore: weGroupData.sensemakerStore,
+      });
+      
+      const devhubHappReleaseHash =
+        this.releaseHashOfAppletInstance(appletInstanceInfo.appletId)!;
+
+      let gui = this._appletGuis.get(devhubHappReleaseHash);
+      if (!gui) {
+        gui = await this.queryAppletGui(devhubHappReleaseHash);
+      }
+
+      const appletConfig = gui.appletConfig;
+      const widgetPairs = gui.widgetPairs;
+      const sensemakerStore = get(this.sensemakerStore(weGroupId));
+      const registeredConfig = await sensemakerStore!.registerApplet(appletConfig);
+      console.log('registeredConfig', registeredConfig)
+      widgetPairs.map((widgetPair) => {
+        console.log('registering widgets to SM store')
+        get(this.sensemakerStore(weGroupId))!.registerWidget(
+          widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(registeredConfig.dimensions[dimensionName])),
+          widgetPair.display,
+          widgetPair.assess,
+        ) 
+      });
+    });
+  }
 }

--- a/ui/app/src/matrix-store.ts
+++ b/ui/app/src/matrix-store.ts
@@ -50,7 +50,7 @@ import {
 } from "@holochain-open-dev/utils";
 import {
   AppletRenderers,
-  NhLauncherApplet,
+  NeighbourhoodApplet,
   AppletInfo,
   NeighbourhoodServices,
   NeighbourhoodInfo,
@@ -171,7 +171,7 @@ export class MatrixStore {
   private _installedAppletClasses: Writable<EntryHashMap<AppletClassInfo>> =
     writable(new EntryHashMap<AppletClassInfo>()); // devhub release entry hashes of Applets as keys
 
-  private _appletGuis: EntryHashMap<NhLauncherApplet> = new EntryHashMap<NhLauncherApplet>(); // devhub hApp release entry hashes of Applets as keys --> no duplicate applet renderers for the same applet class
+  private _appletGuis: EntryHashMap<NeighbourhoodApplet> = new EntryHashMap<NeighbourhoodApplet>(); // devhub hApp release entry hashes of Applets as keys --> no duplicate applet renderers for the same applet class
   private _appletInstanceRenderers: EntryHashMap<AppletRenderers> =
     new EntryHashMap<AppletRenderers>(); // EntryHash of Applet entries in the respective we DNA as keys
   private _appletClassRenderers: EntryHashMap<AppletRenderers> =
@@ -519,7 +519,7 @@ export class MatrixStore {
    * @param devhubHappReleaseHash
    * @returns
    */
-  async queryAppletGui(devhubHappReleaseHash): Promise<NhLauncherApplet> {
+  async queryAppletGui(devhubHappReleaseHash): Promise<NeighbourhoodApplet> {
 
     const appletGui = await this.appletsService.queryAppletGui(devhubHappReleaseHash);
 
@@ -1352,6 +1352,37 @@ export class MatrixStore {
 
       const hcPort = import.meta.env.VITE_AGENT === "2" ? import.meta.env.VITE_HC_PORT_2 : import.meta.env.VITE_HC_PORT;
       const appletAppAgentWebsocket = await AppAgentWebsocket.connect(`ws://localhost:${hcPort}`, appInfo.installed_app_id);
+      
+      
+      const devhubHappReleaseHash =
+        this.releaseHashOfAppletInstance(appletInstanceId)!;
+      // ATTENTION: IT IS ASSUMED HERE THAT THE APPLET IS ALREADY IN THE MATRIX!!
+
+      let gui = this._appletGuis.get(devhubHappReleaseHash);
+      if (!gui) {
+        gui = await this.queryAppletGui(devhubHappReleaseHash);
+      }
+
+      // register applet config and widgets on applet join
+      console.log('register applet config and widgets', gui);
+
+      const appletConfig = gui.appletConfig;
+      const widgetPairs = gui.widgetPairs;
+      const sensemakerStore = get(this.sensemakerStore(weGroupId));
+      await sensemakerStore?.registerApplet(appletConfig);
+      widgetPairs.map((widgetPair) => {
+        console.log('registering widgets to SM store')
+        sensemakerStore!.registerWidget(
+          // [
+          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["importance"]),
+          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["total_importance"]),
+          // ],
+          widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(get(sensemakerStore!.appletConfigs())[installedAppId].dimensions[dimensionName])),
+          widgetPair.display,
+          widgetPair.assess,
+        ) 
+      });
+
       const appInstanceInfo: AppletInstanceInfo = {
         appletId: appletInstanceId,
         appInfo: appInfo,
@@ -1524,6 +1555,35 @@ export class MatrixStore {
 
     const hcPort = import.meta.env.VITE_AGENT === "2" ? import.meta.env.VITE_HC_PORT_2 : import.meta.env.VITE_HC_PORT;
     const appletAppAgentWebsocket = await AppAgentWebsocket.connect(`ws://localhost:${hcPort}`, appInfo.installed_app_id);
+
+      // const devhubHappReleaseHash =
+      //   this.releaseHashOfAppletInstance(appletInstanceId)!;
+      // ATTENTION: IT IS ASSUMED HERE THAT THE APPLET IS ALREADY IN THE MATRIX!!
+
+      // let gui = this._appletGuis.get(devhubHappReleaseHash);
+      // if (!gui) {
+      const  gui = await this.queryAppletGui(applet.devhubHappReleaseHash);
+      // }
+      // register applet config and widgets on applet join
+      console.log('register applet config and widgets', gui);
+
+      const appletConfig = gui.appletConfig;
+      const widgetPairs = gui.widgetPairs;
+      const sensemakerStore = get(this.sensemakerStore(weGroupId));
+      const registeredConfig = await sensemakerStore!.registerApplet(appletConfig);
+      console.log('registeredConfig', registeredConfig)
+      widgetPairs.map((widgetPair) => {
+        console.log('registering widgets to SM store')
+        get(this.sensemakerStore(weGroupId))!.registerWidget(
+          // [
+          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["importance"]),
+          //   encodeHashToBase64(get(this.sensemakerStore.appletConfigs())[installAppId].dimensions["total_importance"]),
+          // ],
+          widgetPair.compatibleDimensions.map((dimensionName: string) => encodeHashToBase64(registeredConfig.dimensions[dimensionName])),
+          widgetPair.display,
+          widgetPair.assess,
+        ) 
+      });
     const appInstanceInfo: AppletInstanceInfo = {
       appletId: appletInstanceId,
       appInfo: appInfo,

--- a/ui/libs/nh-launcher-applet/package.json
+++ b/ui/libs/nh-launcher-applet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neighbourhoods/nh-launcher-applet",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "exports": {

--- a/ui/libs/nh-launcher-applet/package.json
+++ b/ui/libs/nh-launcher-applet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neighbourhoods/nh-launcher-applet",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "exports": {

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -1,22 +1,15 @@
 import { ProfilesStore } from "@holochain-open-dev/profiles";
 import {
-  AdminWebsocket,
-  AppWebsocket,
   AppInfo,
   AppAgentClient,
   EntryHash,
 } from "@holochain/client";
-import { AppletConfig, AppletConfigInput, AssessDimensionWidget, CreateAppletConfigInput, DisplayDimensionWidget, SensemakerStore } from "@neighbourhoods/client";
+import { AssessDimensionWidget, CreateAppletConfigInput, DisplayDimensionWidget, SensemakerStore } from "@neighbourhoods/client";
 
 export type Renderer = (
   rootElement: HTMLElement,
   registry: CustomElementRegistry
 ) => void;
-
-export interface AppletBlock {
-  name: string;
-  render: Renderer;
-}
 
 export type ResourceView = (
   element: HTMLElement,
@@ -49,7 +42,6 @@ export interface NeighbourhoodApplet {
   }[]
 }
 
-
 export interface NeighbourhoodInfo {
   logoSrc: string;
   name: string;
@@ -58,16 +50,3 @@ export interface AppletInfo {
   neighbourhoodInfo: NeighbourhoodInfo,
   appInfo: AppInfo,
 }
-
-// componentStore.getViews(resourceEntryHash, resourceDefEh).{view-type} => html``
-// appletRenderers[${appletName}].
-
-// need a way to map from the resourceDefEh to get the right resource renderer
-
-/*
-{
-  [resourceDefEh: EntryHash]: ResourceView
-}
-
-*/
-

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -4,7 +4,7 @@ import {
   AppAgentClient,
   EntryHash,
 } from "@holochain/client";
-import { AssessDimensionWidget, CreateAppletConfigInput, DisplayDimensionWidget, SensemakerStore } from "@neighbourhoods/client";
+import { ConcreteAssessDimensionWidget, ConcreteDisplayDimensionWidget, CreateAppletConfigInput, SensemakerStore } from "@neighbourhoods/client";
 
 export type Renderer = (
   rootElement: HTMLElement,
@@ -36,8 +36,8 @@ export interface NeighbourhoodApplet {
   ) => Promise<AppletRenderers>;
   appletConfig: CreateAppletConfigInput;
   widgetPairs: {
-    assess: AssessDimensionWidget,
-    display: DisplayDimensionWidget,
+    assess: typeof ConcreteAssessDimensionWidget,
+    display: typeof ConcreteDisplayDimensionWidget,
     compatibleDimensions: string[],
   }[]
 }

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -4,8 +4,9 @@ import {
   AppWebsocket,
   AppInfo,
   AppAgentClient,
+  EntryHash,
 } from "@holochain/client";
-import { SensemakerStore } from "@neighbourhoods/client";
+import { AppletConfig, AppletConfigInput, CreateAppletConfigInput, SensemakerStore } from "@neighbourhoods/client";
 
 export type Renderer = (
   rootElement: HTMLElement,
@@ -17,30 +18,56 @@ export interface AppletBlock {
   render: Renderer;
 }
 
+export type ResourceView = (
+  rootElement: HTMLElement,
+  resourceHash: EntryHash,
+) => void;
+
 export interface AppletRenderers {
   full: Renderer;
-  blocks: Array<AppletBlock>;
+  resourceRenderers: {
+    [resourceDefName: string]: ResourceView;
+  }
 }
 
-export interface WeServices {
+export interface NeighbourhoodServices {
   profilesStore?: ProfilesStore;  // in case of cross-we renderers the profilesStore may not be required
   sensemakerStore?: SensemakerStore;
 }
 
-export interface NhLauncherApplet {
+export interface NeighbourhoodApplet {
   appletRenderers: (
     appAgentWebsocket: AppAgentClient,
-    weStore: WeServices,
+    neighbourhoodStore: NeighbourhoodServices,
     appletInfo: AppletInfo[],
   ) => Promise<AppletRenderers>;
+  appletConfig: CreateAppletConfigInput;
+  widgetPairs: {
+    assess: any,
+    display: any,
+    compatibleDimension: string[],
+  }[]
 }
 
 
-export interface WeInfo {
+export interface NeighbourhoodInfo {
   logoSrc: string;
   name: string;
 }
 export interface AppletInfo {
-  weInfo: WeInfo,
+  neighbourhoodInfo: NeighbourhoodInfo,
   appInfo: AppInfo,
 }
+
+// componentStore.getViews(resourceEntryHash, resourceDefEh).{view-type} => html``
+// appletRenderers[${appletName}].
+
+// need a way to map from the resourceDefEh to get the right resource renderer
+
+/*
+{
+  [resourceDefEh: EntryHash]: ResourceView
+}
+
+*/
+

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -19,8 +19,9 @@ export interface AppletBlock {
 }
 
 export type ResourceView = (
+  element: HTMLElement,
   resourceIdentifier: EntryHash,
-) => any;
+) => void;
 
 export interface AppletRenderers {
   full: Renderer;

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -6,7 +6,7 @@ import {
   AppAgentClient,
   EntryHash,
 } from "@holochain/client";
-import { AppletConfig, AppletConfigInput, CreateAppletConfigInput, SensemakerStore } from "@neighbourhoods/client";
+import { AppletConfig, AppletConfigInput, AssessDimensionWidget, CreateAppletConfigInput, DisplayDimensionWidget, SensemakerStore } from "@neighbourhoods/client";
 
 export type Renderer = (
   rootElement: HTMLElement,
@@ -19,9 +19,8 @@ export interface AppletBlock {
 }
 
 export type ResourceView = (
-  rootElement: HTMLElement,
-  resourceHash: EntryHash,
-) => void;
+  resourceIdentifier: EntryHash,
+) => any;
 
 export interface AppletRenderers {
   full: Renderer;
@@ -43,8 +42,8 @@ export interface NeighbourhoodApplet {
   ) => Promise<AppletRenderers>;
   appletConfig: CreateAppletConfigInput;
   widgetPairs: {
-    assess: any,
-    display: any,
+    assess: AssessDimensionWidget,
+    display: DisplayDimensionWidget,
     compatibleDimensions: string[],
   }[]
 }

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -45,7 +45,7 @@ export interface NeighbourhoodApplet {
   widgetPairs: {
     assess: any,
     display: any,
-    compatibleDimension: string[],
+    compatibleDimensions: string[],
   }[]
 }
 

--- a/ui/libs/nh-launcher-applet/src/index.ts
+++ b/ui/libs/nh-launcher-applet/src/index.ts
@@ -29,10 +29,9 @@ export interface WeServices {
 
 export interface NhLauncherApplet {
   appletRenderers: (
+    appAgentWebsocket: AppAgentClient,
     weStore: WeServices,
     appletInfo: AppletInfo[],
-    appWebsocket?: AppWebsocket,
-    appAgentWebsocket?: AppAgentClient,
   ) => Promise<AppletRenderers>;
 }
 


### PR DESCRIPTION
This PR aims to initialize the views (for widgets and resources) during relevant events (group selection, applet installation, etc.)

[RESOLVED]
Current Issue:
For some reason it seems that the sensemakerStore subscribers in both the sensemaker dashboard and nh-sensemaker-settings don't get updated when the sensemaker store is updated on widget registration. I imaging this is something to do with the it is either being updated, or perhaps the way it is being subscribed to.

For reference, here are the snipped where the subscriber is set up:


```
  connectedCallback() {
    super.connectedCallback();
    let store: Readable<AppletConfig> = this.sensemakerStore?.flattenedAppletConfigs();
    store &&
      store.subscribe(appletConfig => {
        this.appletDetails = appletConfig;
        if (Object.values(appletConfig.resource_defs).length <= 1)
          return console.log("Didn't register the applet's resource defs yet");
```

and 
```
  setupAssessmentsSubscription() {
    let store = this._matrixStore.sensemakerStore(this.selectedWeGroupId);
    store.subscribe(store => {
      (store?.appletConfigs() as Readable<{ [appletName: string]: AppletConfig }>).subscribe(
        appletConfigs => {
```
