### PR TITLE
Feature/126 entry record returned 

### DIFF
--- a/ui/app/src/elements/components/table-filter-map.ts
+++ b/ui/app/src/elements/components/table-filter-map.ts
@@ -18,6 +18,7 @@ import { generateHeaderHTML, cleanResourceNameForUI } from './helpers/functions'
 import { decode } from '@msgpack/msgpack';
 import { MatrixStore } from '../../matrix-store';
 import { matrixContext, weGroupContext } from '../../context';
+import { EntryRecord } from '@holochain-open-dev/utils';
 
 @customElement('dashboard-filter-map')
 export class DashboardFilterMap extends LitElement {
@@ -154,9 +155,9 @@ export class DashboardFilterMap extends LitElement {
   async fetchCurrentContextEntry() {
     if (this.selectedContext == 'none') return;
 
-    const contexts = await this._sensemakerStore.getCulturalContext(this.selectedContext);
+    const context: EntryRecord<CulturalContext> = await this._sensemakerStore.getCulturalContext(this.selectedContext);
     try {
-      this._contextEntry = decode((contexts.entry as any).Present.entry) as CulturalContext;
+      this._contextEntry = context.entry as CulturalContext;
     } catch (error) {
       console.log('No context entry exists for that context entry hash!');
     }

--- a/ui/app/src/nh-config/dimension-list.ts
+++ b/ui/app/src/nh-config/dimension-list.ts
@@ -8,6 +8,7 @@ import { Dimension,  Method,  Range, RangeKind, SensemakerStore } from "@neighbo
 import { NHButton, NHCard, NHComponent } from "@neighbourhoods/design-system-components";
 import { capitalize } from "../elements/components/helpers/functions";
 import { FieldDefinition, FieldDefinitions, Table, TableStore } from "@adaburrows/table-web-component";
+import { EntryRecord } from "@holochain-open-dev/utils";
 
 type InputDimensionTableRecord = {
   ['dimension-name']: string,
@@ -126,7 +127,7 @@ export default class DimensionList extends NHComponent {
     try {
       await this.fetchDimensionEntries()
       await this.fetchRangeEntries()
-      this._methodEntries = await this.sensemakerStore.getMethods();
+      this._methodEntries = (await (this.sensemakerStore.getMethods()) as Array<EntryRecord<Method>>).map(eR => eR.entry);
     } catch (error) {
       console.error('Could not fetch: ', error)
     }

--- a/ui/app/src/nh-config/nh-global-config.ts
+++ b/ui/app/src/nh-config/nh-global-config.ts
@@ -15,6 +15,7 @@ import { provideWeGroupInfo } from '../matrix-helpers';
 import { removeResourceNameDuplicates } from '../utils';
 import { ResourceDef } from '@neighbourhoods/client';
 import { cleanForUI } from '../elements/components/helpers/functions';
+import { EntryRecord } from '@holochain-open-dev/utils';
 
 export default class NHGlobalConfig extends NHComponent {
   @consume({ context: matrixContext, subscribe: true })
@@ -52,7 +53,7 @@ export default class NHGlobalConfig extends NHComponent {
     if(changedProperties.has('weGroupId')) {
       if(!this._sensemakerStore.value) return
       const result = await this._sensemakerStore.value.getResourceDefs()
-      this._resourceDefEntries = removeResourceNameDuplicates(result); // This de-duplicates resources with the same name from other applets (including uninstalled) 
+      this._resourceDefEntries = removeResourceNameDuplicates(result.map((entryRec) => ({...entryRec.entry, resource_def_eh: entryRec.entryHash}))); // This de-duplicates resources with the same name from other applets (including uninstalled) 
     }
   }
   

--- a/ui/libs/app-loader/src/delegateConstructors.ts
+++ b/ui/libs/app-loader/src/delegateConstructors.ts
@@ -18,7 +18,6 @@ import {
   SensemakerStore,
   UnsubscribeFn
 } from "@neighbourhoods/client";
-import { EntryRecord } from "@holochain-open-dev/utils";
 
 export class SubscriberManager extends Array<CallbackFn> {
   public subscribe(cb: CallbackFn): UnsubscribeFn {
@@ -162,8 +161,7 @@ export function createInputAssessmentWidgetDelegate(
         resource_def_eh: resourceDefEh,
         maybe_input_dataset: null
       })
-      const assessmentRecord = await sensemakerStore.getAssessment(assessmentEh)
-      const assessmentEntryRecord = new EntryRecord<Assessment>(assessmentRecord)
+      const assessmentEntryRecord = await sensemakerStore.getAssessment(assessmentEh)
       assessment = assessmentEntryRecord.entry
       subscribers.dispatch(assessment)
       return assessment;

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -40,7 +40,7 @@ interface ContextResults {
 export class SensemakerStore {
   _contextResults: Writable<ContextResults> = writable({});
 
-  ranges: Writable<Map<EntryHashB64, Range>> = writable(new Map<EntryHashB64, Range>());
+  ranges: Writable<Map<EntryHashB64, EntryRecord<Range>>> = writable(new Map<EntryHashB64, EntryRecord<Range>>());
   dimensions: Writable<Map<EntryHashB64, Dimension>> = writable(new Map<EntryHashB64, Dimension>());
   methods: Writable<Map<EntryHashB64, Method>> = writable(new Map<EntryHashB64, Method>());
   resourceDefinitions: Writable<Map<EntryHashB64, ResourceDef>> = writable(new Map<EntryHashB64, ResourceDef>());
@@ -150,13 +150,13 @@ export class SensemakerStore {
     const rangeRecord = await this.service.createRange(range);
     const entryRecord = new EntryRecord<Range>(rangeRecord);
     this.ranges.update(ranges => {
-      ranges.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+      ranges.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
       return ranges;
     });
     return entryRecord.entryHash;
   }
 
-  async getRange(rangeEh: EntryHash): Promise<Range> {
+  async getRange(rangeEh: EntryHash): Promise<EntryRecord<Range>> {
     const range = get(this.ranges).get(encodeHashToBase64(rangeEh));
     if(range) {
       return range;
@@ -165,10 +165,10 @@ export class SensemakerStore {
       const rangeRecord = await this.service.getRange(rangeEh)
       const entryRecord = new EntryRecord<Range>(rangeRecord);
       this.ranges.update(ranges => {
-        ranges.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+        ranges.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
         return ranges;
       });
-      return entryRecord.entry;
+      return entryRecord;
     }
   }
 

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -1,4 +1,3 @@
-import { CulturalContext } from './culturalContext';
 import {
   AgentPubKey,
   AppAgentClient,

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -189,7 +189,7 @@ export class SensemakerStore {
 
     const dimensionEntryRecord = new EntryRecord<Dimension>(dimensionRecord);
     this.dimensions.update(dimensions => {
-      dimensions.set(encodeHashToBase64(dimensionEntryRecord.entryHash), dimensionEntryRecord.entry);
+      dimensions.set(encodeHashToBase64(dimensionEntryRecord.entryHash), dimensionEntryRecord);
       return dimensions;
     });
 
@@ -207,7 +207,7 @@ export class SensemakerStore {
     const dimensionRecord = await this.service.createDimension(dimension);
     const entryRecord = new EntryRecord<Dimension>(dimensionRecord);
     this.dimensions.update(dimensions => {
-      dimensions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+      dimensions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
       return dimensions;
     });
     return entryRecord.entryHash;
@@ -245,7 +245,7 @@ export class SensemakerStore {
     const resourceDefRecord = await this.service.createResourceDef(resourceDef);
     const entryRecord = new EntryRecord<ResourceDef>(resourceDefRecord);
     this.resourceDefinitions.update(resourceDefs => {
-      resourceDefs.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+      resourceDefs.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
       return resourceDefs;
     });
     return entryRecord.entryHash;

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -172,16 +172,16 @@ export class SensemakerStore {
     }
   }
 
-  async getRanges(): Promise<Array<Range>> {
+  async getRanges(): Promise<Array<EntryRecord<Range>>> {
     const rangeRecords = await this.service.getRanges();
     const entryRecords = rangeRecords.map(rangeRecord => new EntryRecord<Range>(rangeRecord));
     this.ranges.update(ranges => {
       entryRecords.forEach(entryRecord => {
-        ranges.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+        ranges.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
       });
       return ranges;
     });
-    return entryRecords.map(entryRecord => entryRecord.entry);
+    return entryRecords;
   }
 
   async createOutputDimensionAndMethodAtomically(input: {outputDimension: Dimension, partialMethod: Partial<Method>}): Promise<{outputDimension: EntryHash, method: EntryHash}> {

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -41,7 +41,7 @@ export class SensemakerStore {
   _contextResults: Writable<ContextResults> = writable({});
 
   ranges: Writable<Map<EntryHashB64, EntryRecord<Range>>> = writable(new Map<EntryHashB64, EntryRecord<Range>>());
-  dimensions: Writable<Map<EntryHashB64, Dimension>> = writable(new Map<EntryHashB64, Dimension>());
+  dimensions: Writable<Map<EntryHashB64, EntryRecord<Dimension>>> = writable(new Map<EntryHashB64, EntryRecord<Dimension>>());
   methods: Writable<Map<EntryHashB64, Method>> = writable(new Map<EntryHashB64, Method>());
   resourceDefinitions: Writable<Map<EntryHashB64, ResourceDef>> = writable(new Map<EntryHashB64, ResourceDef>());
   contexts: Writable<Map<string, Map<EntryHashB64, CulturalContext>>> = writable(new Map<string, Map<EntryHashB64, CulturalContext>>());
@@ -213,7 +213,7 @@ export class SensemakerStore {
     return entryRecord.entryHash;
   }
 
-  async getDimension(dimensionEh: EntryHash): Promise<Dimension> {
+  async getDimension(dimensionEh: EntryHash): Promise<EntryRecord<Dimension>> {
     const dimension = get(this.dimensions).get(encodeHashToBase64(dimensionEh));
     if(dimension) {
       return dimension;
@@ -222,23 +222,23 @@ export class SensemakerStore {
       const dimensionRecord = await this.service.getDimension(dimensionEh)
       const entryRecord = new EntryRecord<Dimension>(dimensionRecord);
       this.dimensions.update(dimensions => {
-        dimensions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+        dimensions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
         return dimensions;
       });
-      return entryRecord.entry;
+      return entryRecord;
     }
   }
 
-  async getDimensions(): Promise<Array<Dimension>> {
+  async getDimensions(): Promise<Array<EntryRecord<Dimension>>> {
     const dimensionRecords = await this.service.getDimensions();
     const entryRecords = dimensionRecords.map(dimensionRecord => new EntryRecord<Dimension>(dimensionRecord));
     this.dimensions.update(dimensions => {
       entryRecords.forEach(entryRecord => {
-        dimensions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+        dimensions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
       });
       return dimensions;
     });
-    return entryRecords.map(entryRecord => entryRecord.entry);
+    return entryRecords;
   }
 
   async createResourceDef(resourceDef: ResourceDef): Promise<EntryHash> {

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -43,7 +43,7 @@ export class SensemakerStore {
   ranges: Writable<Map<EntryHashB64, EntryRecord<Range>>> = writable(new Map<EntryHashB64, EntryRecord<Range>>());
   dimensions: Writable<Map<EntryHashB64, EntryRecord<Dimension>>> = writable(new Map<EntryHashB64, EntryRecord<Dimension>>());
   methods: Writable<Map<EntryHashB64, Method>> = writable(new Map<EntryHashB64, Method>());
-  resourceDefinitions: Writable<Map<EntryHashB64, ResourceDef>> = writable(new Map<EntryHashB64, ResourceDef>());
+  resourceDefinitions: Writable<Map<EntryHashB64, EntryRecord<ResourceDef>>> = writable(new Map<EntryHashB64, EntryRecord<ResourceDef>>());
   contexts: Writable<Map<string, Map<EntryHashB64, CulturalContext>>> = writable(new Map<string, Map<EntryHashB64, CulturalContext>>());
 
   _resourceAssessments: Writable<{ [entryHash: string]: Array<Assessment> }> = writable({});
@@ -251,7 +251,7 @@ export class SensemakerStore {
     return entryRecord.entryHash;
   }
 
-  async getResourceDef(resourceDefEh: EntryHash): Promise<ResourceDef> {
+  async getResourceDef(resourceDefEh: EntryHash): Promise<EntryRecord<ResourceDef>> {
     const resourceDef = get(this.resourceDefinitions).get(encodeHashToBase64(resourceDefEh));
     if(resourceDef) {
       return resourceDef;
@@ -260,10 +260,10 @@ export class SensemakerStore {
       const resourceDefRecord = await this.service.getResourceDef(resourceDefEh)
       const entryRecord = new EntryRecord<ResourceDef>(resourceDefRecord);
       this.resourceDefinitions.update(resourceDefs => {
-        resourceDefs.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+        resourceDefs.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
         return resourceDefs;
       });
-      return entryRecord.entry;
+      return entryRecord;
     }
   }
 
@@ -272,7 +272,7 @@ export class SensemakerStore {
       const entryRecords = resourceDefRecords.map((record: HolochainRecord) => new EntryRecord<ResourceDef>(record));
       this.resourceDefinitions.update(resourceDefinitions => {
         entryRecords.forEach(entryRecord => {
-          resourceDefinitions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+          resourceDefinitions.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
         });
         return resourceDefinitions;
       });

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -267,7 +267,7 @@ export class SensemakerStore {
     }
   }
 
-  async getResourceDefs(): Promise<Array<ResourceDef>> {
+  async getResourceDefs(): Promise<Array<EntryRecord<ResourceDef>>> {
       const resourceDefRecords : HolochainRecord[] = await this.service.getResourceDefs();
       const entryRecords = resourceDefRecords.map((record: HolochainRecord) => new EntryRecord<ResourceDef>(record));
       this.resourceDefinitions.update(resourceDefinitions => {
@@ -276,7 +276,7 @@ export class SensemakerStore {
         });
         return resourceDefinitions;
       });
-      return entryRecords.map(entryRecord => ({...entryRecord.entry, resource_def_eh: entryRecord.entryHash}));
+      return entryRecords
   }
 
   async createAssessment(assessment: CreateAssessmentInput): Promise<EntryHash> {

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -291,8 +291,9 @@ export class SensemakerStore {
     return entryRecord.entryHash;
   }
 
-  async getAssessment(assessmentEh: EntryHash): Promise<HolochainRecord> {
-    return await this.service.getAssessment(assessmentEh)
+  async getAssessment(assessmentEh: EntryHash): Promise<EntryRecord<Assessment>> {
+    const record = await this.service.getAssessment(assessmentEh)
+    return new EntryRecord<Assessment>(record)
   }
 
   async getAssessmentsForResources(getAssessmentsInput: GetAssessmentsForResourceInput): Promise<Record<EntryHashB64, Array<Assessment>>> {

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -42,7 +42,7 @@ export class SensemakerStore {
 
   ranges: Writable<Map<EntryHashB64, EntryRecord<Range>>> = writable(new Map<EntryHashB64, EntryRecord<Range>>());
   dimensions: Writable<Map<EntryHashB64, EntryRecord<Dimension>>> = writable(new Map<EntryHashB64, EntryRecord<Dimension>>());
-  methods: Writable<Map<EntryHashB64, Method>> = writable(new Map<EntryHashB64, Method>());
+  methods: Writable<Map<EntryHashB64, EntryRecord<Method>>> = writable(new Map<EntryHashB64, EntryRecord<Method>>());
   resourceDefinitions: Writable<Map<EntryHashB64, EntryRecord<ResourceDef>>> = writable(new Map<EntryHashB64, EntryRecord<ResourceDef>>());
   contexts: Writable<Map<string, Map<EntryHashB64, CulturalContext>>> = writable(new Map<string, Map<EntryHashB64, CulturalContext>>());
 
@@ -195,7 +195,7 @@ export class SensemakerStore {
 
     const methodEntryRecord = new EntryRecord<Method>(methodRecord);
     this.methods.update(methods => {
-      methods.set(encodeHashToBase64(methodEntryRecord.entryHash), methodEntryRecord.entry);
+      methods.set(encodeHashToBase64(methodEntryRecord.entryHash), methodEntryRecord);
       return methods;
     });
 
@@ -310,13 +310,13 @@ export class SensemakerStore {
     const methodRecord = await this.service.createMethod(method);
     const entryRecord = new EntryRecord<Method>(methodRecord);
     this.methods.update((methods) => {
-      methods.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+      methods.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
       return methods;
     });
     return entryRecord.entryHash;
   }
 
-  async getMethod(methodEh: EntryHash): Promise<Method> {
+  async getMethod(methodEh: EntryHash): Promise<EntryRecord<Method>> {
     const method = get(this.methods).get(encodeHashToBase64(methodEh));
     if (method) {
       return method;
@@ -325,22 +325,22 @@ export class SensemakerStore {
       const methodRecord = await this.service.getMethod(methodEh)
       const entryRecord = new EntryRecord<Method>(methodRecord);
       this.methods.update((methods) => {
-        methods.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+        methods.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
         return methods;
       });
-      return entryRecord.entry;
+      return entryRecord;
     }
   }
-  async getMethods(): Promise<Array<Method>> {
+  async getMethods(): Promise<Array<EntryRecord<Method>>> {
       const methodRecords : HolochainRecord[] = await this.service.getMethods();
       const entryRecords = methodRecords.map((record: HolochainRecord) => new EntryRecord<Method>(record));
       this.methods.update(methods => {
         entryRecords.forEach(entryRecord => {
-          methods.set(encodeHashToBase64(entryRecord.entryHash), entryRecord.entry);
+          methods.set(encodeHashToBase64(entryRecord.entryHash), entryRecord);
         });
         return methods;
       });
-      return entryRecords.map(entryRecord => entryRecord.entry);
+      return entryRecords;
   }
   async getMethodsForDimension(queryParams: GetMethodsForDimensionQueryParams): Promise<Array<Method>> {
     // TODO: get from memory first?

--- a/ui/libs/sensemaker-client/src/sensemakerStore.ts
+++ b/ui/libs/sensemaker-client/src/sensemakerStore.ts
@@ -1,3 +1,4 @@
+import { CulturalContext } from './culturalContext';
 import {
   AgentPubKey,
   AppAgentClient,
@@ -342,12 +343,12 @@ export class SensemakerStore {
       });
       return entryRecords;
   }
-  async getMethodsForDimension(queryParams: GetMethodsForDimensionQueryParams): Promise<Array<Method>> {
+  async getMethodsForDimension(queryParams: GetMethodsForDimensionQueryParams): Promise<Array<EntryRecord<Method>>> {
     // TODO: get from memory first?
       const methodRecords : HolochainRecord[] = await this.service.getMethodsForDimensionEntryHash(queryParams);
       const entryRecords = methodRecords.map((record: HolochainRecord) => new EntryRecord<Method>(record));
 
-      return entryRecords.map(entryRecord => entryRecord.entry);
+      return entryRecords;
   }
 
   async runMethod(runMethodInput: RunMethodInput): Promise<Assessment> {
@@ -378,9 +379,10 @@ export class SensemakerStore {
     return entryRecord.entryHash;
   }
 
-  async getCulturalContext(culturalContextEh: EntryHash): Promise<HolochainRecord> {
+  async getCulturalContext(culturalContextEh: EntryHash): Promise<EntryRecord<CulturalContext>> {
     // :TODO: if we want cultural contexts to be bound to applets, it should be part of the cultural context entry.
-    return await this.service.getCulturalContext(culturalContextEh)
+    const record = await this.service.getCulturalContext(culturalContextEh);
+    return new EntryRecord<CulturalContext>(record)
   }
 
   async computeContext(contextName: string, computeContextInput: ComputeContextInput): Promise<Array<EntryHash>> {
@@ -418,8 +420,7 @@ export class SensemakerStore {
       );
     }
     for (const contextEh of Object.values(appletConfig.cultural_contexts)) {
-      const contextRecord = await this.getCulturalContext(contextEh);
-      const entryRecord = new EntryRecord<CulturalContext>(contextRecord);
+      const entryRecord = await this.getCulturalContext(contextEh);
       this.contexts.update((contexts) => {
         const appletContexts = contexts.get(appletConfig.name);
         if (appletContexts) {


### PR DESCRIPTION
This is a first pass at closing #126,  getting a uniform return type from the store that includes entry hash:

    get[MODEL], get[MODEL]s returns an entry record/array of entry records of that entry type
    create[MODEL] returns an entry hash

Will need a second pass to clear up less standard handlers.

It makes sense to do this part now and integrate in new features so that the dashboard, the global config screens etc. can be refactored to use store methods and not always make a network request.

If an entry type was glossed over in this pass just assume that I was worried about breaking too much! The ones that were changed were barely used in the launcher so far.