### PR TITLE
Feature/event decorator

### DIFF
--- a/ui/app/src/decorators/alert-event.ts
+++ b/ui/app/src/decorators/alert-event.ts
@@ -1,0 +1,63 @@
+interface EventOptions {
+  /** should event bubble through the DOM */
+  bubbles?: boolean;
+  /** event is cancelable */
+  cancelable?: boolean;
+  /** can event bubble between the shadow DOM and the light DOM boundary */
+  composed?: boolean;
+}
+
+export type NHAlertEventOptions = {
+  title: string,
+  msg: string,
+  closable?: boolean,
+}
+
+export class EventEmitter<NHAlertEventOptions> {
+  constructor(private target: HTMLElement, private alertType: "success" | "danger") {}
+
+  emit(value: NHAlertEventOptions, options: EventOptions = { bubbles: true, cancelable: false, composed: true }) {
+    if(!(value?.msg) || !(value?.title)) throw new Error("Invalid alert dispatched");
+
+    this.target.dispatchEvent(
+      new CustomEvent<NHAlertEventOptions>("trigger-alert", { ...options, detail: { type: this.alertType, closable: true, ...value } })
+    );
+  }
+}
+
+/**
+ * Decorator for event emitter for (nh-alert) `trigger-alert` event.
+ * Name the field after the variant of nh-alert that you want to trigger:
+ * `@alertEvent() success;` OR `@alertEvent() danger;`
+ * 
+ *
+ * Then emit like so:
+ *  `this.danger.emit({
+      title: "An error has occurred",
+      msg: "This is the message!"
+    })`
+ */
+export function alertEvent() {
+  return (protoOrDescriptor: any, name: "success" | "danger"): any => {
+    const descriptor = {
+      get(this: HTMLElement) {
+        return new EventEmitter<NHAlertEventOptions>(this, name !== undefined ? name : protoOrDescriptor.key);
+      },
+      enumerable: true,
+      configurable: true,
+    };
+
+    if (name !== undefined) {
+      // legacy TS decorator
+      return Object.defineProperty(protoOrDescriptor, name, descriptor);
+    } else {
+      // TC39 Decorators proposal
+      return {
+        kind: 'method',
+        placement: 'prototype',
+        key: protoOrDescriptor.key,
+        descriptor,
+      };
+    }
+  };
+}

--- a/ui/app/src/elements/components/applet-instance-status-list.ts
+++ b/ui/app/src/elements/components/applet-instance-status-list.ts
@@ -17,6 +17,7 @@ import NHButton from '@neighbourhoods/design-system-components/button';
 import NHDialog from '@neighbourhoods/design-system-components/dialog';
 import NHComponent from '@neighbourhoods/design-system-components/ancestors/base';
 import { b64images } from "@neighbourhoods/design-system-styles";
+import { alertEvent } from "../../decorators/alert-event";
 
 export class AppletInstanceStatusList extends NHComponent {
   @consume({ context: sensemakerStoreContext, subscribe: true })
@@ -39,6 +40,9 @@ export class AppletInstanceStatusList extends NHComponent {
   @query("#uninstall-applet-dialog")
   _uninstallAppletDialog;
 
+  @alertEvent() success;
+  @alertEvent() danger;
+
   @state()
   private _currentAppInfo!: AppletInstanceInfo;
 
@@ -50,33 +54,16 @@ export class AppletInstanceStatusList extends NHComponent {
         this.requestUpdate();
         await this.updateComplete;
 
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Applet Uninstalled",
-              msg: "You will no longer be able to access this applet or its data.",
-              type: "success",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+        this.success.emit({
+          title: "Applet Uninstalled",
+          msg: "You will no longer be able to access this applet or its data."
+        })
       }).catch((e) => {
         console.log("Error: ", e);
-
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Error During Uninstall",
-              msg: "Look in the developer console for more information.",
-              type: "danger",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+        this.danger.emit({
+          title: "Error During Uninstall",
+          msg: "Look in the developer console for more details."
+        })
       });
   }
 

--- a/ui/app/src/elements/components/applet-list-item.ts
+++ b/ui/app/src/elements/components/applet-list-item.ts
@@ -12,12 +12,16 @@ import NHButton from '@neighbourhoods/design-system-components/button';
 import NHPageHeaderCard from '@neighbourhoods/design-system-components/page-header-card';
 import NHDialog from '@neighbourhoods/design-system-components/dialog';;
 import NHComponent from '@neighbourhoods/design-system-components/ancestors/base';
+import { alertEvent } from "../../decorators/alert-event";
 
 export class AppletListItem extends NHComponent {
   @consume({ context: matrixContext , subscribe: true })
   @property({attribute: false})
   matrixStore!: MatrixStore;
 
+  @alertEvent() success;
+  @alertEvent() danger;
+  
   @property()
   sensemakerStore!: SensemakerStore;
 
@@ -40,33 +44,16 @@ export class AppletListItem extends NHComponent {
     const list = (this.parentNode as any);
     this.matrixStore.disableApp(appInfo)
       .then(() => {
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Applet Disabled",
-              msg: "You will no longer be able to use this applet.",
-              type: "success",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+        this.success.emit({
+          title: "Applet Disabled",
+          msg: "You will no longer be able to use this applet."
+        })
       }).catch((e) => {
         console.log("Error: ", e);
-
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Applet Not Disabled",
-              msg: "Look in the developer console for more details.",
-              type: "danger",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+        this.danger.emit({
+          title: "Applet Not Disabled",
+          msg: "Look in the developer console for more details."
+        })
       });
   }
 
@@ -74,32 +61,16 @@ export class AppletListItem extends NHComponent {
     const list = (this.parentNode as any);
     this.matrixStore.enableApp(appInfo)
       .then(() => {
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Applet Enabled",
-              msg: "You can now use this applet.",
-              type: "success",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+        this.success.emit({
+          title: "Applet Enabled",
+          msg: "You can now use this applet."
+        })
       }).catch((e) => {
         console.log("Error: ", e);
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Applet Not Enabled",
-              msg: "Look in the developer console for more details.",
-              type: "danger",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+        this.danger.emit({
+          title: "Applet Not Enabled",
+          msg: "Look in the developer console for more details."
+        })
       });
   }
 

--- a/ui/app/src/elements/components/invitations-block.ts
+++ b/ui/app/src/elements/components/invitations-block.ts
@@ -11,6 +11,7 @@ import NHCard from '@neighbourhoods/design-system-components/card';
 import NHTextInput from '@neighbourhoods/design-system-components/input/text';
 import NHComponent from '@neighbourhoods/design-system-components/ancestors/base';
 import { b64images } from "@neighbourhoods/design-system-styles";
+import { alertEvent } from "../../decorators/alert-event";
 
 export class InvitationsBlock extends NHComponent {
   // TODO: add Yup schema for hash validation
@@ -21,6 +22,9 @@ export class InvitationsBlock extends NHComponent {
   @consume({ context: weGroupContext, subscribe: true })
   @property({attribute: false})
   weGroupId!: DnaHash;
+
+  @alertEvent() success;
+  @alertEvent() danger;
 
   @state()
   _inviteePubKey: AgentPubKeyB64 | undefined;
@@ -34,33 +38,17 @@ export class InvitationsBlock extends NHComponent {
       .then((r) => {
         this._pubkeyField._input.value = "";
         this._inviteePubKey = undefined;
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Invitation sent!",
-              msg: "Your neighbour should now have an invite in their Neighbourhood Home.",
-              type: "success",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        )
+
+        this.success.emit({
+          title: "Invitation sent!",
+          msg: "Your neighbour should now have an invite in their Neighbourhood Home."
+        })
       })
       .catch((e) => {
-        
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "Error. Public key may be invalid.",
-            msg: "Please check that you have copied it from the correct place!",
-            type: "danger",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
+        this.danger.emit({
+          title: "Error. Public key may be invalid.",
+          msg: "Please check that you have copied it from the correct place!"
         })
-      );
         console.log(e);
       });
   }

--- a/ui/app/src/elements/components/join-group-card.ts
+++ b/ui/app/src/elements/components/join-group-card.ts
@@ -17,6 +17,7 @@ import NHButtonGroup from '@neighbourhoods/design-system-components/button-group
 import NHCard from '@neighbourhoods/design-system-components/card';
 import NHComponent from '@neighbourhoods/design-system-components/ancestors/base';
 import { b64images } from '@neighbourhoods/design-system-styles';
+import { alertEvent } from '../../decorators/alert-event';
 
 export class JoinGroupCard extends NHComponent {
   @consume({ context: matrixContext , subscribe: true })
@@ -28,6 +29,9 @@ export class JoinGroupCard extends NHComponent {
     () => this.matrixStore.membraneInvitationsStore.myInvitations,
     () => [this.matrixStore],
   );
+
+  @alertEvent() success;
+  @alertEvent() danger;
 
   async joinGroup(invitationActionHash: ActionHash, invitation: JoinMembraneInvitation) {
     const properties = decode(invitation.clone_dna_recipe.properties) as any;
@@ -51,18 +55,10 @@ export class JoinGroupCard extends NHComponent {
       .catch(e => {
         if (e.data) {
           if (e.data.includes('AppAlreadyInstalled')) {
-            this.dispatchEvent(
-              new CustomEvent("trigger-alert", {
-                detail: { 
-                  title: "Already Installed",
-                  msg: "This applet has already been installed.",
-                  type: "danger",
-                  closable: true,
-                },
-                bubbles: true,
-                composed: true,
-              })
-            )
+            this.danger.emit({
+              title: "Already Installed",
+              msg: "This applet has already been installed."
+            })
           }
         }
       });
@@ -227,22 +223,13 @@ export class JoinGroupCard extends NHComponent {
                   .size=${"auto"}
                   .iconImageB64=${b64images.icons.copy}
                   @click=${() => {
-                    navigator.clipboard.writeText(
-                      encodeHashToBase64(this.matrixStore.myAgentPubKey),
-                      );
-                      this.dispatchEvent(
-                        new CustomEvent("trigger-alert", {
-                          detail: { 
-                            title: "Copied!",
-                            msg: "Now send this to a Neighbour and they will be able to invite you in.",
-                            type: "success",
-                            closable: true,
-                          },
-                          bubbles: true,
-                          composed: true,
-                        })
-                      )
-                      this.requestUpdate();
+                      navigator.clipboard.writeText(
+                        encodeHashToBase64(this.matrixStore.myAgentPubKey),
+                        );
+                      this.success.emit({
+                        title: "Copied!",
+                        msg: "Now send this to a Neighbour and they will be able to invite you in."
+                      })
                     }}
                   >
                   ${generateHashHTML(encodeHashToBase64(this.matrixStore.myAgentPubKey))}

--- a/ui/app/src/elements/components/profile/nh-create-profile.ts
+++ b/ui/app/src/elements/components/profile/nh-create-profile.ts
@@ -11,6 +11,7 @@ import NHForm from '@neighbourhoods/design-system-components/form/form';
 import NHTextInput from '@neighbourhoods/design-system-components/input/text';
 import NHSelectAvatar from '@neighbourhoods/design-system-components/select-avatar';
 import NHComponent from '@neighbourhoods/design-system-components/ancestors/base';
+import { alertEvent } from '../../../decorators/alert-event';
 
 export class NHCreateProfile extends NHComponent {
   @property() profilesStore!: ProfilesStore;
@@ -18,7 +19,8 @@ export class NHCreateProfile extends NHComponent {
   @state() private loading : boolean = false;
 
   @query("nh-button[type='submit']") private _submitBtn;
-  
+  @alertEvent() danger;
+
   _myProfile = new StoreSubscriber(
     this,
     () => this.profilesStore.myProfile,
@@ -46,18 +48,10 @@ export class NHCreateProfile extends NHComponent {
         }),
       );
     } catch (e) {
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "Profile could not be created",
-            msg: "There was a problem creating your profile.",
-            type: "danger",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.danger.emit({
+        title: "Profile could not be created",
+        msg: "There was a problem creating your profile."
+      })
       this.loading = false;
       console.log('Installation error:', e);
     }

--- a/ui/app/src/elements/dashboard/applet-not-installed.ts
+++ b/ui/app/src/elements/dashboard/applet-not-installed.ts
@@ -11,6 +11,7 @@ import { InstallFromFsDialog } from "../dialogs/install-from-file-system";
 
 import NHButton from '@neighbourhoods/design-system-components/button';
 import NHSpinner from '@neighbourhoods/design-system-components/spinner';
+import { alertEvent } from "../../decorators/alert-event";
 
 export class AppletNotInstalled extends ScopedRegistryHost(LitElement) {
   @consume({ context: matrixContext , subscribe: true })
@@ -33,36 +34,14 @@ export class AppletNotInstalled extends ScopedRegistryHost(LitElement) {
   @query("#join-from-fs-dialog")
   joinFromFsDialog!: InstallFromFsDialog;
 
+  @alertEvent() success;
+  @alertEvent() danger;
 
   private toggleAppletDescription() {
     this._showAppletDescription = !this._showAppletDescription;
   }
 
-  async joinApplet() {
-    // (this.shadowRoot?.getElementById("installing-progress") as Snackbar).show();
-
-    await this._matrixStore.joinApplet(this.weGroupId, this.appletInstanceId)
-      .then(() => {
-        this.dispatchEvent(
-          new CustomEvent("applet-installed", {
-            detail: { appletEntryHash: this.appletInstanceId, weGroupId: this.weGroupId },
-            composed: true,
-            bubbles: true,
-            }
-          )
-        );
-        // (this.shadowRoot?.getElementById("installing-progress") as Snackbar).close();
-        // (this.shadowRoot?.getElementById("success-snackbar") as Snackbar).show();
-      }).catch((e) => {
-        console.log("Installation Error: ", e);
-        // (this.shadowRoot?.getElementById("installing-progress") as Snackbar).close();
-        // (this.shadowRoot?.getElementById("error-snackbar") as Snackbar).show();
-      })
-  }
-
   async reinstallApplet() {
-    // (this.shadowRoot?.getElementById("installing-progress") as Snackbar).show();
-
     await this._matrixStore.reinstallApplet(this.weGroupId, this.appletInstanceId)
       .then(() => {
         this.dispatchEvent(
@@ -73,12 +52,16 @@ export class AppletNotInstalled extends ScopedRegistryHost(LitElement) {
             }
           )
         );
-        // (this.shadowRoot?.getElementById("installing-progress") as Snackbar).close();
-        // (this.shadowRoot?.getElementById("success-snackbar") as Snackbar).show();
+        this.success.emit({
+          title: "Success",
+          msg: "Your applet was reinstalled."
+        })
       }).catch((e) => {
         console.log("Installation Error: ", e);
-        // (this.shadowRoot?.getElementById("installing-progress") as Snackbar).close();
-        // (this.shadowRoot?.getElementById("error-snackbar") as Snackbar).show();
+        this.danger.emit({
+          title: "Applet could not be reinstalled",
+          msg: "Check your developer console for more information."
+        })
       })
   }
 

--- a/ui/app/src/elements/dialogs/create-nh-dialog.ts
+++ b/ui/app/src/elements/dialogs/create-nh-dialog.ts
@@ -14,6 +14,7 @@ import NHComponent from '@neighbourhoods/design-system-components/ancestors/base
 import { b64images } from "@neighbourhoods/design-system-styles";
 
 import { InferType, object, string } from "yup";
+import { alertEvent } from "../../decorators/alert-event";
 
 const NH_DEFAULT_LOGO = b64images.nhIcons.logoCol;
 
@@ -30,7 +31,7 @@ export class CreateNeighbourhoodDialog extends NHComponent {
   _neighbourhood: InferType<typeof this._neighbourhoodSchema> = { name: "", image: "" };
 
   @property() openDialogButton!: HTMLElement;
-
+  @alertEvent() danger;
   @query("nh-text-input") _nhInput;
   @query("nh-select-avatar") _nhAvatarSelect;
   @state() validName: boolean = true; // Emulates 'touched = false' initial state
@@ -73,19 +74,12 @@ export class CreateNeighbourhoodDialog extends NHComponent {
       })
       .catch((err) => {
         const dialog = (root.querySelector("nh-dialog") as any).renderRoot.querySelector('sl-dialog');
-        dialog.show() // Stop dialog from closing)
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Invalid Input",
-              msg: "Try filling out the form again!",
-              type: "danger",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        );
+        dialog.show() // Stop dialog from closing
+        this.danger.emit({
+          title: "Invalid Input",
+          msg: "Try filling out the form again!"
+        })
+
         console.log("Error validating profile for field: ", err.path);
       })
   }

--- a/ui/app/src/elements/dialogs/install-from-file-system.ts
+++ b/ui/app/src/elements/dialogs/install-from-file-system.ts
@@ -16,6 +16,7 @@ import NHForm from '@neighbourhoods/design-system-components/form/form';
 import NHSpinner from '@neighbourhoods/design-system-components/spinner';
 
 import { object, string } from 'yup';
+import { alertEvent } from '../../decorators/alert-event';
 
 export class InstallFromFsDialog extends ScopedRegistryHost(LitElement) {
   @consume({ context: matrixContext , subscribe: true })
@@ -27,6 +28,9 @@ export class InstallFromFsDialog extends ScopedRegistryHost(LitElement) {
   weGroupId!: DnaHash;
 
   @state() loading!: boolean;
+
+  @alertEvent() success;
+  @alertEvent() danger;
 
   _allApplets = new StoreSubscriber(
     this,
@@ -84,19 +88,10 @@ export class InstallFromFsDialog extends ScopedRegistryHost(LitElement) {
         this._fileBytes, // compressed webhapp as Uint8Array
       );
       await this.updateComplete;
-
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "Applet Installed",
-            msg: "You can now use your applet, and any assessments made in it will show up on your dashboard.",
-            type: "success",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.success.emit({
+        title: "Applet Installed",
+        msg: "You can now use your applet, and any assessments made in it will show up on your dashboard."
+      })
       
       this.dispatchEvent(
         new CustomEvent('applet-installed', {
@@ -108,18 +103,10 @@ export class InstallFromFsDialog extends ScopedRegistryHost(LitElement) {
       this.loading = false;
     } catch (e) {
       this.resetLocalState()
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "Applet Could Not Be Installed",
-            msg: "There was a problem installing your applet. Please check that you have a valid and functioning webhapp bundle.",
-            type: "danger",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.danger.emit({
+        title: "Applet Could Not Be Installed",
+        msg: "There was a problem installing your applet. Please check that you have a valid and functioning webhapp bundle."
+      })
       this.loading = false;
       console.log('Installation error:', e);
     }

--- a/ui/app/src/elements/dialogs/leave-neighbourhood.ts
+++ b/ui/app/src/elements/dialogs/leave-neighbourhood.ts
@@ -11,6 +11,7 @@ import { consume } from "@lit/context";
 import { DnaHash } from "@holochain/client";
 import { matrixContext } from "../../context";
 import { MatrixStore } from "../../matrix-store";
+import { alertEvent } from "../../decorators/alert-event";
 
 export class LeaveNeighbourhood extends NHComponent {
   @consume({ context: matrixContext , subscribe: true })
@@ -30,36 +31,23 @@ export class LeaveNeighbourhood extends NHComponent {
     this._dialog.showDialog();
   }
 
+  @alertEvent() success;
+  @alertEvent() danger;
+
   async leaveGroup() {
     const weGroupName = this._matrixStore.getNeighbourhoodInfo(this.weGroupId)?.name;
     try {
       await this._matrixStore.leaveWeGroup(this.weGroupId, true);
       await this.updateComplete;
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "Neighbourhood Left Successfully",
-            msg: "You will no longer be a part of this Neighbourhood.",
-            type: "success",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.success.emit({
+        title: "Neighbourhood Left Successfully",
+        msg: "You will no longer be a part of this Neighbourhood."
+      })
     } catch (e) {
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "Error while leaving Neighbourhood",
-            msg: "Check your developer console for more information.",
-            type: "success",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.danger.emit({
+        title: "Error while leaving Neighbourhood",
+        msg: "Check your developer console for more information."
+      })
       console.log("Error while leaving neighbourhood:", e);
     };
 

--- a/ui/app/src/nh-config/lists/dashboard-filter-map.ts
+++ b/ui/app/src/nh-config/lists/dashboard-filter-map.ts
@@ -26,6 +26,7 @@ import { derived } from 'svelte/store';
 import { compareUint8Arrays, createInputAssessmentWidgetDelegate, InputAssessmentRenderer } from '../../../../libs/app-loader';
 import { appletInstanceInfosContext } from '../../context';
 import NHComponent from '@neighbourhoods/design-system-components/ancestors/base';
+import { alertEvent } from '../../decorators/alert-event';
 
 type DecoratorProps = {
   renderer: AssessmentWidgetRenderer,
@@ -68,7 +69,8 @@ export class DashboardFilterMap extends NHComponent {
     }),
     () => [this.loaded],
   );
-
+  @alertEvent() danger
+  
   @property() selectedContext;
   @property() selectedContextEhB64!: EntryHashB64;
   @property() resourceDefEntries!: object[];
@@ -251,18 +253,10 @@ export class DashboardFilterMap extends NHComponent {
         }
       }
     } catch (error) {
-        this.dispatchEvent(
-          new CustomEvent("trigger-alert", {
-            detail: { 
-              title: "Some Controls Not Configured",
-              msg: "Your controls have not all been configured correctly -  go to the *Assessments* screen to configure them!",
-              type: "danger",
-              closable: true,
-            },
-            bubbles: true,
-            composed: true,
-          })
-        );
+      this.danger.emit({
+        title: "Some Controls Not Configured",
+        msg: "Your controls have not all been configured correctly -  go to the *Assessments* screen to configure them!"
+      })
     }
     return baseRecord;
   }

--- a/ui/app/src/nh-config/lists/dashboard-table.ts
+++ b/ui/app/src/nh-config/lists/dashboard-table.ts
@@ -18,6 +18,7 @@ import { InputAssessmentRenderer, OutputAssessmentRenderer, ResourceBlockRendere
 import { appletInstanceInfosContext } from '../../context';
 import { consume } from '@lit/context';
 import { WithProfile } from '../../elements/components/profile/with-profile';
+import { alertEvent } from '../../decorators/alert-event';
 
 export const tableId = 'assessmentsForResource';
 
@@ -49,6 +50,8 @@ export class DashboardTable extends NHComponent {
   contextFieldDefs!: { [x: string]: FieldDefinition<AssessmentTableRecord> };
   @property()
   tableType!: AssessmentTableType;
+  
+  @alertEvent() success;
 
   async updateTable() {
     this.tableStore.fieldDefs = this.generateFieldDefs(this.resourceName, this.contextFieldDefs);
@@ -66,18 +69,10 @@ export class DashboardTable extends NHComponent {
     } 
 
     if(!this.loading && this.tableStore.records.length == 0 && this.assessments.length == 0) {
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "No Assessments Found",
-            msg: "Go to your applets to start making assessments.",
-            type: "success",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.success.emit({
+        title: "No Assessments Found",
+        msg: "Go to your applets to start making assessments."
+      })
       this.showSkeleton = true;
     }
     if(typeof this.contextFieldDefs == 'object') this.columns = Object.values(this.contextFieldDefs).length + 2

--- a/ui/app/src/nh-config/pages/nh-dashboard-overview.ts
+++ b/ui/app/src/nh-config/pages/nh-dashboard-overview.ts
@@ -12,6 +12,7 @@ import NHSkeleton from '@neighbourhoods/design-system-components/skeleton';
 import { b64images } from '@neighbourhoods/design-system-styles';
 
 import TabbedContextTables from '../lists/tabbed-context-tables';
+import { alertEvent } from '../../decorators/alert-event';
 import { property, state } from 'lit/decorators.js';
 import { SensemakerStore, AppletConfig } from '@neighbourhoods/client';
 import { derived } from 'svelte/store';
@@ -49,7 +50,9 @@ export default class NHDashBoardOverview extends NHComponent {
     }),
     () => [this._currentAppletInstances],
   );
-
+  
+  @alertEvent() success;
+  
   @state() _currentAppletContexts : any[] = [];
 
   protected async firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>) {
@@ -64,19 +67,10 @@ export default class NHDashBoardOverview extends NHComponent {
   protected updated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
 
     if(this.loaded && !(this._currentAppletInstances?.value && Object.values(this._currentAppletInstances.value).length > 0)) {
-      
-      this.dispatchEvent(
-        new CustomEvent("trigger-alert", {
-          detail: { 
-            title: "No Applets Installed",
-            msg: "You cannot use the Sensemaker dashboard without installing and using applets.",
-            type: "success",
-            closable: true,
-          },
-          bubbles: true,
-          composed: true,
-        })
-      );
+      this.success.emit({
+        title: "No Applets Installed",
+        msg: "You cannot use the Sensemaker dashboard without installing and using applets."
+      })
     }  
   }
 


### PR DESCRIPTION
Closes #201  and #200 

Adds an event decorator to succinctly dispatch the `trigger-alert` event with the associated alert type (success/danger) depending on the class property name.

Replaces the `this.dispatchEvent` instances across the codebase.

Gets rid of some unused code in `applet-not-installed.ts`